### PR TITLE
Fix assembly names for .NET 6 libs

### DIFF
--- a/NCneticCore.Net6/NCneticCore.Net6.csproj
+++ b/NCneticCore.Net6/NCneticCore.Net6.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <Nullable>enable</Nullable>
+    <AssemblyName>NCneticCore</AssemblyName>
+    <RootNamespace>NCneticCore</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="..\NCneticCore\FAO.cs" Link="FAO.cs" />
+    <Compile Include="..\NCneticCore\ncJob.cs" Link="ncJob.cs" />
+    <Compile Include="..\NCneticCore\ncMachine.cs" Link="ncMachine.cs" />
+    <Compile Include="..\NCneticCore\ncParser.cs" Link="ncParser.cs" />
+    <Compile Include="..\NCneticCore\UTIL.cs" Link="UTIL.cs" />
+  </ItemGroup>
+</Project>

--- a/NCneticCore.Net6/Properties/AssemblyInfo.cs
+++ b/NCneticCore.Net6/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("NCneticCore")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("NCneticCore")]
+[assembly: AssemblyCopyright("Copyright ©  2023")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("9d3e16be-a704-40f9-aec1-fc39da1f8715")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/NCneticCore.View.Net6/NCneticCore.View.Net6.csproj
+++ b/NCneticCore.View.Net6/NCneticCore.View.Net6.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net6.0-windows</TargetFramework>
+    <UseWindowsForms>true</UseWindowsForms>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <Nullable>enable</Nullable>
+    <AssemblyName>NCneticCore.View</AssemblyName>
+    <RootNamespace>NCneticCore.View</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\NCneticCore.Net6\NCneticCore.Net6.csproj" />
+    <PackageReference Include="OpenTK" Version="3.1.0" />
+    <PackageReference Include="OpenTK.GLControl" Version="3.1.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\NCneticCore.View\CAO.cs" Link="CAO.cs" />
+    <Compile Include="..\NCneticCore.View\ncView.cs" Link="ncView.cs" />
+    <Compile Include="..\NCneticCore.View\VSFS.cs" Link="VSFS.cs" />
+  </ItemGroup>
+</Project>

--- a/NCneticCore.View.Net6/Properties/AssemblyInfo.cs
+++ b/NCneticCore.View.Net6/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("NCneticCore.View")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("NCneticCore.View")]
+[assembly: AssemblyCopyright("Copyright ©  2023")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("7f3e9dc0-46ae-49b6-85a9-d84383605dbf")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/NCneticStandalone.sln
+++ b/NCneticStandalone.sln
@@ -1,0 +1,34 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NCneticCore.Net6", "NCneticCore.Net6\NCneticCore.Net6.csproj", "{DE50545C-B54F-40B9-8FE5-445B7260CB0F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NCneticCore.View.Net6", "NCneticCore.View.Net6\NCneticCore.View.Net6.csproj", "{F8EAF0CA-030D-4A31-B43A-97304F6AF225}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NCneticStandalone", "NCneticStandalone\NCneticStandalone.csproj", "{1F5F51C4-EE7E-4405-AF28-7CCECB9109E6}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{DE50545C-B54F-40B9-8FE5-445B7260CB0F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DE50545C-B54F-40B9-8FE5-445B7260CB0F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DE50545C-B54F-40B9-8FE5-445B7260CB0F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DE50545C-B54F-40B9-8FE5-445B7260CB0F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F8EAF0CA-030D-4A31-B43A-97304F6AF225}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F8EAF0CA-030D-4A31-B43A-97304F6AF225}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F8EAF0CA-030D-4A31-B43A-97304F6AF225}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F8EAF0CA-030D-4A31-B43A-97304F6AF225}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1F5F51C4-EE7E-4405-AF28-7CCECB9109E6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1F5F51C4-EE7E-4405-AF28-7CCECB9109E6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1F5F51C4-EE7E-4405-AF28-7CCECB9109E6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1F5F51C4-EE7E-4405-AF28-7CCECB9109E6}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/NCneticStandalone/MainForm.cs
+++ b/NCneticStandalone/MainForm.cs
@@ -1,0 +1,135 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Windows.Forms;
+using NCneticCore;
+using NCneticCore.View;
+using OpenTK;
+using OpenTK.Graphics.OpenGL;
+
+namespace NCneticStandalone
+{
+    public class MainForm : Form
+    {
+        private RichTextBox editor = new RichTextBox();
+        private GLControl glControl = new GLControl();
+        private ncView view;
+        private ncJob job = new ncJob();
+        private ncMachine machine = new ncMachine();
+        private TrackBar trackBar = new TrackBar();
+        private SplitContainer split = new SplitContainer();
+        private MenuStrip menu = new MenuStrip();
+        private ToolStripMenuItem fileMenu = new ToolStripMenuItem("File");
+        private ToolStripMenuItem openItem = new ToolStripMenuItem("Open");
+        private ToolStripMenuItem reloadItem = new ToolStripMenuItem("Reload");
+        private ToolStripMenuItem exitItem = new ToolStripMenuItem("Exit");
+        private string currentFile = string.Empty;
+
+        public MainForm()
+        {
+            Text = "NCnetic Standalone";
+            Width = 1000;
+            Height = 700;
+
+            split.Dock = DockStyle.Fill;
+            split.SplitterDistance = 350;
+            split.Panel1.Controls.Add(editor);
+            split.Panel2.Controls.Add(glControl);
+            editor.Dock = DockStyle.Fill;
+            glControl.Dock = DockStyle.Fill;
+            Controls.Add(split);
+            Controls.Add(trackBar);
+            Controls.Add(menu);
+
+            menu.Items.Add(fileMenu);
+            fileMenu.DropDownItems.Add(openItem);
+            fileMenu.DropDownItems.Add(reloadItem);
+            fileMenu.DropDownItems.Add(new ToolStripSeparator());
+            fileMenu.DropDownItems.Add(exitItem);
+
+            trackBar.Dock = DockStyle.Bottom;
+            trackBar.Minimum = 0;
+            trackBar.ValueChanged += TrackBar_ValueChanged;
+
+            openItem.Click += OpenItem_Click;
+            reloadItem.Click += ReloadItem_Click;
+            exitItem.Click += (s,e) => Close();
+
+            view = new ncView(new ncViewOptions());
+            view.IniGraphicContext(glControl.Handle);
+            view.ViewPortLoad(glControl.Width, glControl.Height);
+            HookViewEvents();
+        }
+
+        private void HookViewEvents()
+        {
+            glControl.Resize += (s, e) => view.ViewChangeSize(glControl.Width, glControl.Height);
+            glControl.Paint += (s, e) =>
+            {
+                view.ViewPortPaint();
+                glControl.SwapBuffers();
+            };
+            view.Refresh += (s, e) => glControl.Invalidate();
+            view.MoveSelected += (s, e) =>
+            {
+                int selId = job.MoveList.FindIndex(m => m.MoveGuid == e.guid);
+                if (selId >= 0)
+                {
+                    trackBar.Value = selId;
+                    HighlightLine(job.MoveList[selId].Line);
+                }
+            };
+        }
+
+        private void TrackBar_ValueChanged(object sender, EventArgs e)
+        {
+            if (job.MoveList.Any() && trackBar.Value < job.MoveList.Count)
+            {
+                view.SelectMove(job.MoveList[trackBar.Value]);
+                HighlightLine(job.MoveList[trackBar.Value].Line);
+            }
+        }
+
+        private void HighlightLine(int line)
+        {
+            if (line >= 0 && line < editor.Lines.Length)
+            {
+                int idx = editor.GetFirstCharIndexFromLine(line);
+                editor.SelectionStart = idx;
+                editor.ScrollToCaret();
+            }
+        }
+
+        private void OpenItem_Click(object sender, EventArgs e)
+        {
+            using OpenFileDialog dlg = new OpenFileDialog();
+            if (dlg.ShowDialog() == DialogResult.OK)
+            {
+                currentFile = dlg.FileName;
+                LoadFile(currentFile);
+            }
+        }
+
+        private void ReloadItem_Click(object sender, EventArgs e)
+        {
+            if (!string.IsNullOrEmpty(currentFile) && File.Exists(currentFile))
+            {
+                LoadFile(currentFile);
+            }
+        }
+
+        private void LoadFile(string file)
+        {
+            editor.Text = File.ReadAllText(file);
+            job = new ncJob { FileName = file, Text = editor.Text };
+            job.Process(machine);
+            job.EndProcessing += (s, e) =>
+            {
+                view.LoadJob(job);
+                view.Recenter();
+                trackBar.Maximum = Math.Max(0, job.MoveList.Count - 1);
+                trackBar.Value = 0;
+            };
+        }
+    }
+}

--- a/NCneticStandalone/NCneticStandalone.csproj
+++ b/NCneticStandalone/NCneticStandalone.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net6.0-windows</TargetFramework>
+    <UseWindowsForms>true</UseWindowsForms>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\NCneticCore.Net6\NCneticCore.Net6.csproj" />
+    <ProjectReference Include="..\NCneticCore.View.Net6\NCneticCore.View.Net6.csproj" />
+    <PackageReference Include="OpenTK" Version="3.1.0" />
+    <PackageReference Include="OpenTK.GLControl" Version="3.1.0" />
+  </ItemGroup>
+</Project>

--- a/NCneticStandalone/Program.cs
+++ b/NCneticStandalone/Program.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Windows.Forms;
+
+namespace NCneticStandalone
+{
+    static class Program
+    {
+        [STAThread]
+        static void Main()
+        {
+            Application.EnableVisualStyles();
+            Application.SetCompatibleTextRenderingDefault(false);
+            Application.Run(new MainForm());
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- set assembly and namespace names for `NCneticCore.Net6`
- set assembly and namespace names for `NCneticCore.View.Net6`
- remove Windows-only flags from `NCneticCore.Net6` so it builds on any platform

## Testing
- `dotnet build NCneticStandalone.sln -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68796754ec54832f9e65ad23d6a5c015